### PR TITLE
Fix creating new obligees

### DIFF
--- a/poleno/datasheets/fields.py
+++ b/poleno/datasheets/fields.py
@@ -74,7 +74,10 @@ class Field(object):
 class FloatField(Field):
 
     def has_changed(self, obj, value):
-        return abs(getattr(obj, self.name) - value) > 1e-7
+        try:
+            return abs(getattr(obj, self.name) - value) > 1e-7
+        except TypeError:
+            return True
 
 class FieldChoicesField(Field):
 


### PR DESCRIPTION
Nefungovalo vytvaranie novych Obligees. Pretoze porovnanie, ci sa zmenila latitude/longitude padlo na tom, ze povodna hodnota bola `None`.

@mmmaly Pls checkoutni si branchu ku sebe a over, ci to uz funguje. Testuj niekde inde nez v produkcii.