### PR TITLE
 #212 Allow null in Inforequest.published

### DIFF
--- a/chcemvediet/apps/inforequests/cron.py
+++ b/chcemvediet/apps/inforequests/cron.py
@@ -210,7 +210,7 @@ def publish_inforequests():
 
     inforequests = (Inforequest.objects
             .closed()
-            .not_published()
+            .published_unknown()
             )
 
     filtered = []

--- a/chcemvediet/apps/inforequests/migrations/0022_inforequest_published.py
+++ b/chcemvediet/apps/inforequests/migrations/0022_inforequest_published.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='inforequest',
             name='published',
-            field=models.BooleanField(default=False, help_text='True if the inforequest is published and everybody can see it. Non-published inforequests can be seen only by the user who created them.'),
+            field=models.NullBooleanField(default=False, help_text='NULL if the inforequest will never be published automatically. False if the inforequest will be published automatically. True if the inforequest is published and everybody can see it. Non-published inforequests can be seen only by the user who created them.'),
             preserve_default=True,
         ),
     ]

--- a/chcemvediet/apps/inforequests/migrations/0022_inforequest_published.py
+++ b/chcemvediet/apps/inforequests/migrations/0022_inforequest_published.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='inforequest',
             name='published',
-            field=models.NullBooleanField(default=False, help_text='NULL if the inforequest will never be published automatically. False if the inforequest will be published automatically. True if the inforequest is published and everybody can see it. Non-published inforequests can be seen only by the user who created them.'),
+            field=models.NullBooleanField(help_text='NULL if the inforequest will be published automatically. False if the inforequest will never be published automatically. True if the inforequest is published and everybody can see it. Non-published inforequests can be seen only by the user who created them.'),
             preserve_default=True,
         ),
     ]

--- a/chcemvediet/apps/inforequests/models/inforequest.py
+++ b/chcemvediet/apps/inforequests/models/inforequest.py
@@ -28,7 +28,7 @@ class InforequestQuerySet(QuerySet):
         return self.filter(published=True)
     def not_published(self):
         return self.filter(published=False)
-    def never_published(self):
+    def published_unknown(self):
         return self.filter(published=None)
     def with_undecided_email(self):
         return self.filter(inforequestemail__type=InforequestEmail.TYPES.UNDECIDED).distinct()
@@ -117,10 +117,11 @@ class Inforequest(FormatMixin, models.Model):
             help_text=squeeze(u"""
                 True if the inforequest is closed and the applicant may not act on it any more.
                 """))
-    published = models.NullBooleanField(default=False,
+
+    published = models.NullBooleanField(
             help_text=squeeze(u"""
-                NULL if the inforequest will never be published automatically. False if the
-                inforequest will be published automatically. True if the inforequest is published
+                NULL if the inforequest will be published automatically. False if the
+                inforequest will never be published automatically. True if the inforequest is published
                 and everybody can see it. Non-published inforequests can be seen only by the user
                 who created them.
             """))

--- a/chcemvediet/apps/inforequests/models/inforequest.py
+++ b/chcemvediet/apps/inforequests/models/inforequest.py
@@ -28,6 +28,8 @@ class InforequestQuerySet(QuerySet):
         return self.filter(published=True)
     def not_published(self):
         return self.filter(published=False)
+    def never_published(self):
+        return self.filter(published=None)
     def with_undecided_email(self):
         return self.filter(inforequestemail__type=InforequestEmail.TYPES.UNDECIDED).distinct()
     def without_undecided_email(self):
@@ -115,12 +117,12 @@ class Inforequest(FormatMixin, models.Model):
             help_text=squeeze(u"""
                 True if the inforequest is closed and the applicant may not act on it any more.
                 """))
-
-    # May NOT be NULL
-    published = models.BooleanField(default=False,
+    published = models.NullBooleanField(default=False,
             help_text=squeeze(u"""
-                True if the inforequest is published and everybody can see it. Non-published
-                inforequests can be seen only by the user who created them.
+                NULL if the inforequest will never be published automatically. False if the
+                inforequest will be published automatically. True if the inforequest is published
+                and everybody can see it. Non-published inforequests can be seen only by the user
+                who created them.
             """))
 
     # May be NULL; Used by ``cron.undecided_email_reminder``

--- a/chcemvediet/apps/inforequests/models/inforequest.py
+++ b/chcemvediet/apps/inforequests/models/inforequest.py
@@ -120,10 +120,10 @@ class Inforequest(FormatMixin, models.Model):
 
     published = models.NullBooleanField(
             help_text=squeeze(u"""
-                NULL if the inforequest will be published automatically. False if the
-                inforequest will never be published automatically. True if the inforequest is published
-                and everybody can see it. Non-published inforequests can be seen only by the user
-                who created them.
+                NULL if the inforequest will be published automatically. False if the inforequest
+                will never be published automatically. True if the inforequest is published and
+                everybody can see it. Non-published inforequests can be seen only by the user who
+                created them.
             """))
 
     # May be NULL; Used by ``cron.undecided_email_reminder``


### PR DESCRIPTION
@martinmacko47 Navrhoval by som, aby `False` vyjadroval ziadosti, ktore budu automaticky zverejnene. Tym padom je potrebnych menej oprav v kode.
Admin rozhranie defaultne pre hodnotu `NULL` pouziva piktogram otaznik a choice field s hodnotami `True, False, Unknown`, cize podla mna netreba menit admin rozhranie.
V Crone sa taktiez nic nezmeni, kedze selektujeme iba `inforequest.not_published()`.

Mam doplnit aj dokumentaciu pre `Inforequest`? Pri issue, kde sme prepisovali dokumentaciu do `.md`, si spominal ze celu dokumentaciu aj s inymi zmenami prerobime v samostantom PR.

Ak predsa len chces, aby bola `NULL` hodnota pre ziadosti ktore sa budu automaticky zverejnovat, tak daj vediet a prerobim to.