### PR TITLE
#172 Remove impossible wizard results from docs

### DIFF
--- a/misc/assets/obligee-action-wizard-table.svg
+++ b/misc/assets/obligee-action-wizard-table.svg
@@ -85,9 +85,9 @@
     <text class="cell" x="375">✓</text>
     <text class="cell" x="425">✓</text>
     <text class="cell" x="475">✓</text>
-    <text class="cell err" x="525">Ref.</text>
-    <text class="cell err" x="575">Ref.</text>
-    <text class="cell err" x="625">Ref.</text>
+    <text class="cell" x="525">—</text>
+    <text class="cell" x="575">—</text>
+    <text class="cell" x="625">—</text>
     <text class="cell help" x="675">H</text>
   </g>
 
@@ -100,9 +100,9 @@
     <text class="cell" x="375">✓</text>
     <text class="cell" x="425">✓</text>
     <text class="cell" x="475">✓</text>
-    <text class="cell err" x="525">Ref.</text>
-    <text class="cell err" x="575">Ref.</text>
-    <text class="cell err" x="625">Ref.</text>
+    <text class="cell" x="525">—</text>
+    <text class="cell" x="575">—</text>
+    <text class="cell" x="625">—</text>
     <text class="cell help" x="675">H</text>
   </g>
 
@@ -115,9 +115,9 @@
     <text class="cell" x="375">✓</text>
     <text class="cell" x="425">✓</text>
     <text class="cell" x="475">✓</text>
-    <text class="cell err" x="525">Ref.</text>
-    <text class="cell err" x="575">Ref.</text>
-    <text class="cell err" x="625">Ref.</text>
+    <text class="cell" x="525">—</text>
+    <text class="cell" x="575">—</text>
+    <text class="cell" x="625">—</text>
     <text class="cell help" x="675">H</text>
   </g>
 
@@ -130,9 +130,9 @@
     <text class="cell help" x="375">H</text>
     <text class="cell help" x="425">H</text>
     <text class="cell help" x="475">H</text>
-    <text class="cell help" x="525">H</text>
-    <text class="cell help" x="575">H</text>
-    <text class="cell help" x="625">H</text>
+    <text class="cell" x="525">—</text>
+    <text class="cell" x="575">—</text>
+    <text class="cell" x="625">—</text>
     <text class="cell help" x="675">H</text>
   </g>
 
@@ -145,9 +145,9 @@
     <text class="cell" x="375">✓</text>
     <text class="cell" x="425">✓</text>
     <text class="cell" x="475">✓</text>
-    <text class="cell err" x="525">Ref.</text>
-    <text class="cell err" x="575">Ref.</text>
-    <text class="cell err" x="625">Ref.</text>
+    <text class="cell" x="525">—</text>
+    <text class="cell" x="575">—</text>
+    <text class="cell" x="625">—</text>
     <text class="cell help" x="675">H</text>
   </g>
 
@@ -160,9 +160,9 @@
     <text class="cell help" x="375">H</text>
     <text class="cell help" x="425">H</text>
     <text class="cell help" x="475">H</text>
-    <text class="cell help" x="525">H</text>
-    <text class="cell help" x="575">H</text>
-    <text class="cell help" x="625">H</text>
+    <text class="cell" x="525">—</text>
+    <text class="cell" x="575">—</text>
+    <text class="cell" x="625">—</text>
     <text class="cell help" x="675">H</text>
   </g>
 

--- a/misc/assets/obligee-action-wizard-table.svg
+++ b/misc/assets/obligee-action-wizard-table.svg
@@ -1,6 +1,6 @@
-<svg version="1.1" viewBox="0 0 900 830" xmlns="http://www.w3.org/2000/svg">
+<svg version="1.1" viewBox="0 0 900 940" xmlns="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <style>
-      text {
+      text, foreignObject {
         font-family: sans-serif;
         font-size: 12pt;
       }
@@ -14,14 +14,20 @@
       }
       .help {
         fill: green;
+        color: green;
       }
       .err {
         fill: red;
+        color: red;
       }
       .grid {
         fill: none;
         stroke: black;
         stroke-width: 1pt;
+      }
+      .legend {
+        font-size: 10pt;
+        padding: 5pt;
       }
   </style>
 
@@ -314,6 +320,26 @@
     <text class="cell help" x="575">H</text>
     <text class="cell help" x="625">H</text>
     <text class="cell help" x="675">H</text>
+  </g>
+
+  <g transform="translate(100 740)">
+    <foreignObject x="0" y="0" width="700" height="100">
+      <xhtml:div class="legend">
+        <xhtml:span>✓</xhtml:span>:
+          The wizard correctly categorizes the new action.
+          <xhtml:br/>
+        <xhtml:span class="help">H</xhtml:span>:
+          The new action is invalid in such case and the wizard ends with a help request.
+          <xhtml:br/>
+        <xhtml:span class="err">Ref.</xhtml:span>/<xhtml:span class="err">Disc.</xhtml:span>:
+          The new action is invalid in such case, but the wizard ends with a categorization as the
+          given wrong action type. Such cases are very rare, however, so we don't care about them.
+          <xhtml:br/>
+        <xhtml:span>—</xhtml:span>:
+          The new action is impossible in such case, so we don't care what wizard does for it.
+          <xhtml:br/>
+      </xhtml:div>
+    </foreignObject>
   </g>
 
 </svg>

--- a/misc/inforequests.md
+++ b/misc/inforequests.md
@@ -480,13 +480,6 @@ Overview of wizard results:
 
 ![](assets/obligee-action-wizard-table.svg)
 
-_Legend_:
-* Tick: The wizard correctly categorizes the new action.
-* Dash: The new action is impossible in such cases, so we don't care what wizard does about them.
-* Green H: The new action is invalid in such case and the wizard ends with a help request.
-* Red action type: The new action is invalid in such case, but the wizard ends with a categorization
-  as a wrong action type. Such cases are very rare, however, so we don't care about them.
-
 ## Events
 
 ### Received E-mail

--- a/misc/inforequests.md
+++ b/misc/inforequests.md
@@ -480,12 +480,12 @@ Overview of wizard results:
 
 ![](assets/obligee-action-wizard-table.svg)
 
-Black tick: The wizard correctly categorizes the new action.
-
-Green H: The new action is invalid in such case and the wizard ends with a help request.
-
-Red action type: The new action is invalid in such case, but the wizard ends with a categorization
-as a wrong action type. Such cases are very rare, however, so we don't care about them.
+_Legend_:
+* Tick: The wizard correctly categorizes the new action.
+* Dash: The new action is impossible in such cases, so we don't care what wizard does about them.
+* Green H: The new action is invalid in such case and the wizard ends with a help request.
+* Red action type: The new action is invalid in such case, but the wizard ends with a categorization
+  as a wrong action type. Such cases are very rare, however, so we don't care about them.
 
 ## Events
 


### PR DESCRIPTION
Pre akcie, ktore podla "Inforequest Flow" mozu nastat iba pred Appeal v ramci jednej brache, nemusime riesit, co spravi wizard, ak po nich pride akcia Remandment, Affirmation alebo Reversion. Kedze Remandment, Affirmation ani Reversion prist nemozu nastat prad Appeal.

Preto som v "Overview of wizard results" tabulke tieto pripady oznacil "—", tj. ze nenastavaju.