### PR TITLE
#239 Fix UnicodeDecodeError by subprocess32.run stdout and stderr

### DIFF
--- a/chcemvediet/apps/anonymization/finalization.py
+++ b/chcemvediet/apps/anonymization/finalization.py
@@ -56,14 +56,16 @@ def finalize_using_libreoffice(attachment_anonymization):
                     successful=True,
                     file=ContentFile(file_pdf.read()),
                     content_type=content_types.PDF_CONTENT_TYPE,
-                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(p.stdout, p.stderr)
+                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(unicode(p.stdout, u'utf-8'),
+                                                             unicode(p.stderr, u'utf-8'),
+                                                             )
                 )
             cron_logger.info(u'Finalized attachment using libreoffice: {}'.format(
                 attachment_anonymization))
     except Exception as e:
         trace = unicode(traceback.format_exc(), u'utf-8')
-        stdout = p.stdout if p else getattr(e, u'stdout', u'')
-        stderr = p.stderr if p else getattr(e, u'stderr', u'')
+        stdout = unicode(p.stdout if p else getattr(e, u'stdout', ''), u'utf-8')
+        stderr = unicode(p.stderr if p else getattr(e, u'stderr', ''), u'utf-8')
         AttachmentFinalization.objects.create(
             attachment=attachment_anonymization.attachment,
             successful=False,

--- a/chcemvediet/apps/anonymization/normalization.py
+++ b/chcemvediet/apps/anonymization/normalization.py
@@ -65,13 +65,15 @@ def normalize_using_libreoffice(attachment):
                     successful=True,
                     file=ContentFile(file_pdf.read()),
                     content_type=content_types.PDF_CONTENT_TYPE,
-                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(p.stdout, p.stderr)
+                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(unicode(p.stdout, u'utf-8'),
+                                                             unicode(p.stderr, u'utf-8'),
+                                                             )
                 )
             cron_logger.info(u'Normalized attachment using libreoffice: {}'.format(attachment))
     except Exception as e:
         trace = unicode(traceback.format_exc(), u'utf-8')
-        stdout = p.stdout if p else getattr(e, u'stdout', u'')
-        stderr = p.stderr if p else getattr(e, u'stderr', u'')
+        stdout = unicode(p.stdout if p else getattr(e, u'stdout', ''), u'utf-8')
+        stderr = unicode(p.stderr if p else getattr(e, u'stderr', ''), u'utf-8')
         AttachmentNormalization.objects.create(
             attachment=attachment,
             successful=False,
@@ -105,13 +107,15 @@ def normalize_using_imagemagic(attachment):
                     successful=True,
                     file=ContentFile(file_pdf.read()),
                     content_type=content_types.PDF_CONTENT_TYPE,
-                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(p.stdout, p.stderr)
+                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(unicode(p.stdout, u'utf-8'),
+                                                             unicode(p.stderr, u'utf-8'),
+                                                             )
                 )
             cron_logger.info(u'Normalized attachment using imagemagic: {}'.format(attachment))
     except Exception as e:
         trace = unicode(traceback.format_exc(), u'utf-8')
-        stdout = p.stdout if p else getattr(e, u'stdout', u'')
-        stderr = p.stderr if p else getattr(e, u'stderr', u'')
+        stdout = unicode(p.stdout if p else getattr(e, u'stdout', ''), u'utf-8')
+        stderr = unicode(p.stderr if p else getattr(e, u'stderr', ''), u'utf-8')
         AttachmentNormalization.objects.create(
             attachment=attachment,
             successful=False,

--- a/chcemvediet/apps/anonymization/recognition.py
+++ b/chcemvediet/apps/anonymization/recognition.py
@@ -55,14 +55,16 @@ def recognize_using_ocr(attachment_normalization):
                     successful=True,
                     file=ContentFile(file_odt.read()),
                     content_type=content_types.ODT_CONTENT_TYPE,
-                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(p.stdout, p.stderr)
+                    debug=u'STDOUT:\n{}\nSTDERR:\n{}'.format(unicode(p.stdout, u'utf-8'),
+                                                             unicode(p.stderr, u'utf-8'),
+                                                             )
                 )
             cron_logger.info(u'Recognized attachment_normalization using OCR: {}'.format(
                 attachment_normalization))
     except Exception as e:
         trace = unicode(traceback.format_exc(), u'utf-8')
-        stdout = p.stdout if p else getattr(e, u'stdout', u'')
-        stderr = p.stderr if p else getattr(e, u'stderr', u'')
+        stdout = unicode(p.stdout if p else getattr(e, u'stdout', ''), u'utf-8')
+        stderr = unicode(p.stderr if p else getattr(e, u'stderr', ''), u'utf-8')
         AttachmentRecognition.objects.create(
             attachment=attachment_normalization.attachment,
             successful=False,


### PR DESCRIPTION
Python3 funkcia subprocess.run ma kwarg `encoding` co by vyriesilo tento bug. Bohuzial subprocess32.run hovori ze tento argument funkcie nepozna. Preto treba konvertovat string `<str>` na `<unicode>`. V tomto commite som `stdout` a `stderr` formatoval na `<unicode>`. Dalsie riesenie je, ak by sme ako debug spravu neformatovali na `<unicode>`:

```
debug='STDOUT:\n{}\nSTDERR:\n{}\n{}'.format(stdout, stderr, trace)  # bez prefixu `u`
```