### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You need the following packages installed:
 The following packages are also recommended, but you can configure `setup.py` to use mocks
 instead of them:
 
- * libreoffice
+ * libreoffice (ver. 6.3.4+)
  * imagemagick
  * [abbyyocr11]
 
@@ -132,7 +132,7 @@ You need the following packages installed
  * python-dev
  * libmysqlclient-dev
  * libapache2-mod-wsgi
- * libreoffice
+ * libreoffice (ver. 6.3.4+, on Ubuntu, you might want to use `sudo add-apt-repository ppa:libreoffice/ppa`)
  * imagemagick
  * libmagic (ver. 5.25+, package `libmagic1`)
  * webp


### PR DESCRIPTION
libreoffice 6.0 (default Ubuntu as of time) produces sometimes error: TimeoutExpired: Command '[u'libreoffice', u'--headless', u'--convert-to', u'pdf', u'--outdir', '/tmp/tmp1YdQcJ', u'/tmp/tmp1YdQcJ/file.xlsx']' timed out after 300 seconds"