### PR TITLE
#367 Fix MySQL charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,10 @@ You need the following packages installed
 
 #### 2.1.1. MySQL Configuration
 
-Make sure your database has configured UTF-8 charset with correct collation:
+Make sure your database has configured correct UTF-8 charset with full 4-byte support and with
+correct collation:
 
-	mysql> alter database {database} character set utf8 collate utf8_general_ci;
+	mysql> alter database {database} character set utf8mb4 collate utf8mb4_general_ci;
 
 Where `{database}` is your database name. You must alter database charset before creating any
 tables, otherwise they will keep the old charset.

--- a/chcemvediet/settings/server_dev.py
+++ b/chcemvediet/settings/server_dev.py
@@ -14,6 +14,7 @@ DATABASES = {
     u'default': {
         u'ENGINE': u'django.db.backends.mysql',
         u'CONN_MAX_AGE': 60,
+        u'OPTIONS': {'charset': 'utf8mb4'},
         # Filled in 'configured.py'
         u'NAME': u'',
         u'USER': u'',

--- a/chcemvediet/settings/server_dev_no_debug.py
+++ b/chcemvediet/settings/server_dev_no_debug.py
@@ -15,6 +15,7 @@ DATABASES = {
     u'default': {
         u'ENGINE': u'django.db.backends.mysql',
         u'CONN_MAX_AGE': 60,
+        u'OPTIONS': {'charset': 'utf8mb4'},
         # Filled in 'configured.py'
         u'NAME': u'',
         u'USER': u'',

--- a/chcemvediet/settings/server_prod.py
+++ b/chcemvediet/settings/server_prod.py
@@ -24,6 +24,7 @@ DATABASES = {
     u'default': {
         u'ENGINE': u'django.db.backends.mysql',
         u'CONN_MAX_AGE': 60,
+        u'OPTIONS': {'charset': 'utf8mb4'},
         # Filled in 'configured.py'
         u'NAME': u'',
         u'USER': u'',

--- a/misc/Dockerfile
+++ b/misc/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     libssl-dev \
     cron \
     git \
+    vim \
     # Dependencies
     apache2 \
     mysql-server \
@@ -41,7 +42,7 @@ RUN \
   /etc/init.d/mysql start && \
   printf "%s\n" \
     "create database chcemvediet;" \
-    "alter database chcemvediet character set utf8 collate utf8_general_ci;" \
+    "alter database chcemvediet character set utf8mb4 collate utf8mb4_general_ci;" \
     "grant all privileges on chcemvediet.* to chcemvediet@localhost identified by 'nbusr123';" \
     | mysql && \
   :
@@ -131,6 +132,10 @@ RUN \
     # Unique cache key prefix (default)
     "" \
     # Google Custom Search API key (default)
+    "" \
+    # Google reCaptcha public key (default)
+    "" \
+    # Google reCaptcha private key (default)
     "" \
     # Load datasheets / Neighbourhood dummy was omitted / Delete it?
     "y" \


### PR DESCRIPTION
First you need to change default character set for the entire DB:

```sql
alter database chcemvediet character set utf8mb4 collate utf8mb4_general_ci;
```

Then you need to change default character set for **all** existing tables in DB:

```sql
alter table XXXXX convert to character set utf8mb4 collate utf8mb4_general_ci;
...
```

Where `XXXXX` is name of table.

And finally you need to apply the patch in this PR.