### PR TITLE
#334 Fix amend template tag context

### DIFF
--- a/poleno/utils/templates/utils/tests/amendtemplatetagtest/test_amend_tag_on_imported_content.html
+++ b/poleno/utils/templates/utils/tests/amendtemplatetagtest/test_amend_tag_on_imported_content.html
@@ -1,0 +1,9 @@
+{% load prepend from poleno.amend %}
+
+<ul>
+  <li>aaa</li>
+  <li>bbb</li>
+</ul>
+
+{% prepend path=".//ul" %}<li>xxx</li>{% endprepend %}
+{% prepend path=".//li" %}!{% endprepend %}

--- a/poleno/utils/tests/test_templatetags.py
+++ b/poleno/utils/tests/test_templatetags.py
@@ -451,6 +451,26 @@ class AmendTemplatetagTest(TestCase):
                 u'</ul>'
                 u'')
 
+    def test_amend_tag_with_operation_tags_before_content(self):
+        rendered = self._render(
+                u'{% load amend prepend from poleno.amend %}'
+                u'{% amend %}'
+                u'  {% prepend path=".//ul" %}<li>xxx</li>{% endprepend %}'
+                u'  {% prepend path=".//li" %}!{% endprepend %}'
+                u'  <ul>'
+                u'    <li>aaa</li>'
+                u'    <li>bbb</li>'
+                u'  </ul>'
+                u'{% endamend %}'
+                u'')
+        self.assertHTMLEqual(rendered,
+                u'<ul>'
+                u'  <li>!xxx</li>'
+                u'  <li>!aaa</li>'
+                u'  <li>!bbb</li>'
+                u'</ul>'
+                u'')
+
     def test_amend_tag_on_plain_text(self):
         rendered = self._render(
                 u'{% load amend prepend append from poleno.amend %}'
@@ -479,6 +499,21 @@ class AmendTemplatetagTest(TestCase):
                 u'<p>bbb</p>'
                 u'<p>ccc</p>'
                 u'<p>yyy</p>'
+                u'')
+
+    def test_amend_tag_on_imported_content(self):
+        rendered = self._render(
+                u'{% load amend from poleno.amend %}'
+                u'{% amend %}'
+                u'  {% include "utils/tests/amendtemplatetagtest/test_amend_tag_on_imported_content.html" %}'
+                u'{% endamend %}'
+                u'')
+        self.assertHTMLEqual(rendered,
+                u'<ul>'
+                u'  <li>!xxx</li>'
+                u'  <li>!aaa</li>'
+                u'  <li>!bbb</li>'
+                u'</ul>'
                 u'')
 
     def test_multiple_amend_tags(self):
@@ -511,6 +546,82 @@ class AmendTemplatetagTest(TestCase):
                 u'  <li>aaa!</li>'
                 u'  <li>bbb!</li>'
                 u'  <li>xxx!</li>'
+                u'</ul>'
+                u'')
+
+    def test_nested_amend_tags(self):
+        rendered = self._render(
+                u'{% load amend prepend append from poleno.amend %}'
+                u'{% amend %}'
+                u'  <ul>'
+                u'    <li>aaa</li>'
+                u'    <li>bbb</li>'
+                u'    <li>'
+                u'      {% amend %}'
+                u'        <ul>'
+                u'          <li>aaa</li>'
+                u'          <li>bbb</li>'
+                u'        </ul>'
+                u'        {% append path=".//ul" %}<li>yyy</li>{% endappend %}'
+                u'        {% append path=".//li" %}?{% endappend %}'
+                u'      {% endamend %}'
+                u'    </li>'
+                u'  </ul>'
+                u'  {% prepend path=".//ul" %}<li>xxx</li>{% endprepend %}'
+                u'  {% prepend path=".//li" %}!{% endprepend %}'
+                u'{% endamend %}'
+                u'')
+        self.assertHTMLEqual(rendered,
+                u'<ul>'
+                u'  <li>!xxx</li>'
+                u'  <li>!aaa</li>'
+                u'  <li>!bbb</li>'
+                u'  <li>!'
+                u'    <ul>'
+                u'      <li>!xxx</li>'
+                u'      <li>!aaa?</li>'
+                u'      <li>!bbb?</li>'
+                u'      <li>!yyy?</li>'
+                u'    </ul>'
+                u'  </li>'
+                u'</ul>'
+                u'')
+
+    def test_nested_amend_tags_with_operation_tags_before_content(self):
+        rendered = self._render(
+                u'{% load amend prepend append from poleno.amend %}'
+                u'{% amend %}'
+                u'  {% prepend path=".//ul" %}<li>xxx</li>{% endprepend %}'
+                u'  {% prepend path=".//li" %}!{% endprepend %}'
+                u'  <ul>'
+                u'    <li>aaa</li>'
+                u'    <li>bbb</li>'
+                u'    <li>'
+                u'      {% amend %}'
+                u'        {% append path=".//ul" %}<li>yyy</li>{% endappend %}'
+                u'        {% append path=".//li" %}?{% endappend %}'
+                u'        <ul>'
+                u'          <li>aaa</li>'
+                u'          <li>bbb</li>'
+                u'        </ul>'
+                u'      {% endamend %}'
+                u'    </li>'
+                u'  </ul>'
+                u'{% endamend %}'
+                u'')
+        self.assertHTMLEqual(rendered,
+                u'<ul>'
+                u'  <li>!xxx</li>'
+                u'  <li>!aaa</li>'
+                u'  <li>!bbb</li>'
+                u'  <li>!'
+                u'    <ul>'
+                u'      <li>!xxx</li>'
+                u'      <li>!aaa?</li>'
+                u'      <li>!bbb?</li>'
+                u'      <li>!yyy?</li>'
+                u'    </ul>'
+                u'  </li>'
                 u'</ul>'
                 u'')
 


### PR DESCRIPTION
Oprava `{% amend %}` template tagu, aby spravne pracoval s svojou context premennou `_amend`.

Doteraz sa `_amend` premenna do kontextu vkladala az pri prvom pouziti tagov ako `{% prepend %}` a podobne, ktore si premennu `_amend` v kontexte vytvorili sami. To vsak sposobovalo problem, ze ak sa `{% prepend %}` nachadzalo v importnutom sub-template, tak django pri importovani sub-templatu vytvorilo novu vrstvu kontextu `context.push()`, ktora sa na konci importnuteho sum-template zahodila `context.pop()`, cim sa stratila premenna `_amend`, ktoru do kontextu vlozil `{% prepend %}`. 

Bug bol zakerny v tom, ze sa prejavoval iba ak `{% prepend %}` bolo pouzite v sub-template, a to aj iba vtedy, ak v hlavnom template nebol predtym pouzity nejaky iny tag, ktory by premmenu `_amend` do contextu uz pridal. Pretoze, ak premenna `_amend` v kontexte uz pri importe sub-template bola, vytvorenie novej vrstvy kontextu ju zachovalo a tak tag `{% prepend %}` v sub-template mal nadalej pristup k `_amend` z hlavneho templatu, do ktoreho zapisal svoje data.

Bug som fixol tak, ze premenna `_amend` sa do kontextu prida hned na zaciatku pri otvarajucom tagu `{% amend %}`. Takze vsetky taky ako `{% prepend %}` vo vnutri `{% amend %}` budu mat premennu `_amend` uz k dispozicii v kontexte, bez ohladu na to, ci sa nachadzaju v hlavnom template, alebo v sub-template.

Navyse na zaciatku pri otvarajucom tagu `{% amend %}` okrem pridania `_amend` do kontextu, vyrobim v kontexte novu vrstvu, ktoru na konci, za `{% endamend %}` dropnem (kontext manager `with context.push` ju dropne automaticky). Takze by mali fungovat aj vnorene `{% amend %}` tagy. Pri vnorenych `{% amend %}` tagov kazdy `{% amend %}` tag aplikuje tie prikazy, ktore su v jeho vrstve kontextu.

Pls poriadne pretestuj, ci to funguje, alebo ci sa nieco nepokazilo niekde.

Edit: Pridal som dva testy, ktore na aktualnom masteri failuju a na tomto PR vyzeraju, ze uz funguju. Pls pozri ich a pretestuj:
- `test_amend_tag_on_imported_content`
- `test_nested_amend_tags_with_operation_tags_before_content`